### PR TITLE
Generate automatically a draft of release note

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,38 @@
+---
+# Labels names are important as they are used by Release Drafter to decide
+# regarding where to record them in changelog or if to skip them.
+#
+# The repository label will be autoaticalluu configured using this file and
+# the GitHub Action https://github.com/marketplace/actions/github-labeler.
+- name: invalid
+  description: This doesn't seem right
+  color: e4e669
+- name: performance
+  description: A code change that improves performance
+  color: f3ffb2
+- name: python
+  description: Pull requests that update Python code
+  color: 2b67c6
+- name: question
+  description: Further information is requested
+  color: d876e3
+- name: refactoring
+  description: A code change that neither fixes a bug nor adds a feature
+  color: d4c5f9
+- name: removal
+  description: Removals and Deprecations
+  color: f00000
+- name: style
+  description:
+    Changes that do not affect the meaning of the code (white-space, formatting,
+    etc)
+  color: ffc6df
+- name: task
+  description:
+  color: d88c70
+- name: testing
+  description: Adding missing tests or correcting existing tests
+  color: 79e57f
+- name: wontfix
+  description: This will not be worked on
+  color: ffffff

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,6 +4,42 @@
 #
 # The repository label will be autoaticalluu configured using this file and
 # the GitHub Action https://github.com/marketplace/actions/github-labeler.
+- name: breaking
+  description: Breaking Changes
+  color: 7c3ea5
+- name: bug
+  description: Something isn't working
+  color: d73a4a
+- name: build
+  description: Changes that affect the build system or external dependencies
+  color: fc964e
+- name: ci
+  description: Changes to CI configuration files and scripts
+  color: 00485e
+- name: cookiecutter
+  description: Changes outside of the template directory
+  color: f9ffb2
+- name: dependencies
+  description: Dependencies
+  color: 00ce44
+- name: documentation
+  description: Improvements or additions to documentation
+  color: 0075ca
+- name: duplicate
+  description: This issue or pull request already exists
+  color: cfd3d7
+- name: enhancement
+  description: New feature or request
+  color: a2eeef
+- name: github_actions
+  description: Pull requests that update Github_actions code
+  color: "000000"
+- name: good first issue
+  description: Good for newcomers
+  color: 7057ff
+- name: help wanted
+  description: Extra attention is needed
+  color: 008672
 - name: invalid
   description: This doesn't seem right
   color: e4e669

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,29 @@
+categories:
+  - title: ":boom: Breaking Changes"
+    label: "breaking"
+  - title: ":rocket: Features"
+    label: "enhancement"
+  - title: ":fire: Removals and Deprecations"
+    label: "removal"
+  - title: ":beetle: Fixes"
+    label: "bug"
+  - title: ":racehorse: Performance"
+    label: "performance"
+  - title: ":rotating_light: Testing"
+    label: "testing"
+  - title: ":construction_worker: Continuous Integration"
+    label: "ci"
+  - title: ":books: Documentation"
+    label: "documentation"
+  - title: ":hammer: Refactoring"
+    label: "refactoring"
+  - title: ":lipstick: Style"
+    label: "style"
+  - title: ":package: Dependencies"
+    labels:
+      - "dependencies"
+      - "build"
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Labeler
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2.3.3
+
+      - name: Run Labeler
+        if: success()
+        uses: crazy-max/ghaction-github-labeler@v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          skip-delete: true
+          dry-run: false
+          exclude: |
+            hacktoberfest*

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,12 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - main
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.12.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use GitHub Action release-drafter for release note generation
Use crazy-max/ghaction-github-labeler for labels management => Needed to have consistency between project labels and labels expected by release drafter.
