### PR TITLE
Reduce to one version reference in the doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,9 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=2020.11.16
+   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=|current-stable-version|
+
+.. |current-stable-version| replace:: 2020.11.16
 
 .. usage-end
 
@@ -93,9 +95,10 @@ Creating a project
 
 Generate a Home Assistant custom component project by using the following command:
 
-.. include:: ../README.rst
-   :start-after: usage-begin
-   :end-before: usage-end
+.. code:: console
+
+   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=|current-stable-version|
+
 
 Follow the instructions to customize the generated project
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Usage
 
 .. parsed-literal::
 
-   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=|current-stable-version|
+   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=\ |current-stable-version|\
 
 .. |current-stable-version| replace:: 2020.11.16
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,6 @@ Usage
 
    $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=\ |current-stable-version|\
 
-.. |current-stable-version| replace:: 2020.11.16
 
 .. usage-end
 
@@ -97,7 +96,7 @@ Generate a Home Assistant custom component project by using the following comman
 
 .. parsed-literal::
 
-   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=|current-stable-version|
+   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=\ |current-stable-version|\
 
 
 Follow the instructions to customize the generated project
@@ -199,6 +198,7 @@ Known limitations
 
 .. references-begin
 
+.. |current-stable-version| replace:: 2020.11.16
 .. _Black: https://github.com/psf/black
 .. _integration_blueprint: https://github.com/custom-components/integration_blueprint
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter

--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,13 @@ __ https://cookiecutter-homeassistant-custom-component.readthedocs.io/
 Usage
 =====
 
+.. usage-begin
+
 .. code:: console
 
    $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=2020.11.16
 
+.. usage-end
 
 Features
 ========
@@ -90,10 +93,9 @@ Creating a project
 
 Generate a Home Assistant custom component project by using the following command:
 
-.. code:: console
-
-   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component \
-     --checkout="2020.11.16"
+.. include:: ../README.rst
+   :start-after: usage-begin
+   :end-before: usage-end
 
 Follow the instructions to customize the generated project
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Usage
 
 .. usage-begin
 
-.. code:: console
+.. parsed-literal::
 
    $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=|current-stable-version|
 
@@ -95,7 +95,7 @@ Creating a project
 
 Generate a Home Assistant custom component project by using the following command:
 
-.. code:: console
+.. parsed-literal::
 
    $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=|current-stable-version|
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,11 +28,9 @@ and `cookiecutter-hypermodern-python`_ projects.
 Usage
 -----
 
-.. code:: console
-
-   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component \
-     --checkout="2020.11.16"
-
+.. include:: ../README.rst
+   :start-after: usage-begin
+   :end-before: usage-end
 
 Features
 --------


### PR DESCRIPTION
To avoid updating latest stable reference in the documentation in many
places.

Fix: #65