### PR TITLE
Add CI tests for template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         include:
           - { python-version: 3.9, os: ubuntu-latest }
-          - { python-version: 3.9, os: windows-latest }
+          # - { python-version: 3.9, os: windows-latest }
           - { python-version: 3.9, os: macos-latest }
           - { python-version: 3.8, os: ubuntu-latest }
-          - { python-version: 3.7, os: ubuntu-latest }
+          # - { python-version: 3.7, os: ubuntu-latest }
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8 reorder-python-imports
           pip install -r requirements_test.txt
+        working-directory: awesome-custom-component
 
       - name: Run pre-commit on all files
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,96 @@
+name: Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { python-version: 3.9, os: ubuntu-latest }
+          - { python-version: 3.9, os: windows-latest }
+          - { python-version: 3.9, os: macos-latest }
+          - { python-version: 3.8, os: ubuntu-latest }
+          - { python-version: 3.7, os: ubuntu-latest }
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          path: cookiecutter-homeassistant-custom-component
+      - uses: actions/setup-python@v2.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tools using pip
+        working-directory: cookiecutter-homeassistant-custom-component
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install --constraint=.github/workflows/constraints.txt cookiecutter
+      - name: Generate project using Cookiecutter
+        run: cookiecutter --no-input cookiecutter-homeassistant-custom-component
+      - name: Create git repository
+        if: matrix.os != 'windows-latest'
+        run: |
+          git init
+          git config --local user.name "GitHub Action"
+          git config --local user.email "action@github.com"
+          git add .
+          git commit --message="Initial import"
+        working-directory: awesome-custom-component
+      - name: Create git repository (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          git init
+          git config --local user.name "GitHub Action"
+          git config --local user.email "action@github.com"
+          # https://github.com/cookiecutter/cookiecutter/issues/405
+          $ErrorActionPreference = "Continue"
+          git add .
+          $ErrorActionPreference = "Stop"
+          git add --renormalize .
+          git commit --message="Initial import"
+        working-directory: awesome-custom-component
+      - name: Compute cache key for pre-commit
+        if: matrix.os != 'windows-latest'
+        id: cache_key
+        shell: python
+        run: |
+          import hashlib
+          import sys
+
+          python = "py{}.{}".format(*sys.version_info[:2])
+          payload = sys.version.encode() + sys.executable.encode()
+          digest = hashlib.sha256(payload).hexdigest()
+          result = "${{ runner.os }}-{}-{}-pre-commit".format(python, digest)
+
+          print("::set-output name=result::{}".format(result))
+      - uses: actions/cache@v2.1.3
+        if: matrix.os != 'windows-latest'
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ steps.cache_key.outputs.result }}-${{ hashFiles('awesome-custom-component/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ steps.cache_key.outputs.result }}-
+      - name: Install Python modules
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8 reorder-python-imports
+          pip install -r requirements_test.txt
+
+      - name: Run pre-commit on all files
+        run: |
+          pre-commit run --all-files --show-diff-on-failure --color=always
+        working-directory: awesome-custom-component
+
+      - name: Tests suite
+        run: |
+          pytest \
+            --timeout=9 \
+            --durations=10 \
+            -n auto \
+            -p no:sugar \
+            tests
+        working-directory: awesome-custom-component

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt pip
           pip install --constraint=.github/workflows/constraints.txt cookiecutter
       - name: Generate project using Cookiecutter
-        run: ./scripts/gen_instance
+        run: cookiecutter-homeassistant-custom-component/scripts/gen_instance
       - name: Create git repository
         if: matrix.os != 'windows-latest'
         run: |
@@ -40,7 +40,7 @@ jobs:
           git config --local user.email "action@github.com"
           git add .
           git commit --message="Initial import"
-        working-directory: awesome-custom-component
+        working-directory: cookiecutter-homeassistant-custom-component-instance
       - name: Create git repository (Windows)
         if: matrix.os == 'windows-latest'
         run: |
@@ -53,7 +53,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           git add --renormalize .
           git commit --message="Initial import"
-        working-directory: awesome-custom-component
+        working-directory: cookiecutter-homeassistant-custom-component-instance
       - name: Compute cache key for pre-commit
         if: matrix.os != 'windows-latest'
         id: cache_key
@@ -72,19 +72,19 @@ jobs:
         if: matrix.os != 'windows-latest'
         with:
           path: ~/.cache/pre-commit
-          key: ${{ steps.cache_key.outputs.result }}-${{ hashFiles('awesome-custom-component/.pre-commit-config.yaml') }}
+          key: ${{ steps.cache_key.outputs.result }}-${{ hashFiles('cookiecutter-homeassistant-custom-component-instance/.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ steps.cache_key.outputs.result }}-
       - name: Install Python modules
         run: |
           pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8 reorder-python-imports
           pip install -r requirements_test.txt
-        working-directory: awesome-custom-component
+        working-directory: cookiecutter-homeassistant-custom-component-instance
 
       - name: Run pre-commit on all files
         run: |
           pre-commit run --all-files --show-diff-on-failure --color=always
-        working-directory: awesome-custom-component
+        working-directory: cookiecutter-homeassistant-custom-component-instance
 
       - name: Tests suite
         run: |
@@ -94,4 +94,4 @@ jobs:
             -n auto \
             -p no:sugar \
             tests
-        working-directory: awesome-custom-component
+        working-directory: cookiecutter-homeassistant-custom-component-instance

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt pip
           pip install --constraint=.github/workflows/constraints.txt cookiecutter
       - name: Generate project using Cookiecutter
-        run: cookiecutter --no-input cookiecutter-homeassistant-custom-component
+        run: ./scripts/gen_instance
       - name: Create git repository
         if: matrix.os != 'windows-latest'
         run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,7 +69,10 @@ from your development version:
 How to test the project
 -----------------------
 
-You can manually test the generated integration with different tools implemented in Github workflows.
+This template repository has a Continuous Integration workflow that generate a default project
+from the cookiecutter template and run tests on it.
+
+You can also manually test the generated integration with different tools implemented in Github workflows.
 
 This template repository is linked to a generated `instance repository`_ for testing purpose.
 You can generate this instance by using the following command:


### PR DESCRIPTION
Fix: #116 

Template CI generates a project and run pre-commit and pytest suite.

Thos OS and Python version have been removed: 
- Windows is failing for an not yet understood reason and Windows is not a really a supported OS for Home Assistant development.
- Python 3.7 is no more supported by [the lib used for pytest suite](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component).
