### PR TITLE
Fix git clone failure

### DIFF
--- a/{{cookiecutter.project_name}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_name}}/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
-  "image": "ludeeus/container:integration-debian",
+  "image": "ghcr.io/ludeeus/devcontainer/integration:stable",
   "name": "{{cookiecutter.friendly_name}} integration development",
   "context": "..",
   "appPort": ["9123:8123"],


### PR DESCRIPTION
Imports fix for https://github.com/custom-components/integration_blueprint/pull/73
Fixes error with git clone (tries to use old git protocol, which is disabled by github: https://github.blog/2021-09-01-improving-git-protocol-security-github/)