### PR TITLE
Update README.rst uage section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ It is recommended to use the latest stable version by using the command:
 
 .. parsed-literal::
 
-   $ cookiecutter gh:oncleben31/homeassistant-custom-component \\
+   $ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component \\
      --checkout=\ |current-stable-version|\
 
 


### PR DESCRIPTION
Updates the usage section. 

Previous error:
```
$ cookiecutter gh:oncleben31/homeassistant-custom-component --checkout=2021.1.1
The repository https://github.com/oncleben31/homeassistant-custom-component.git could not be found, have you made a typo?
```

With this change:
```
$ cookiecutter gh:oncleben31/cookiecutter-homeassistant-custom-component --checkout=2021.1.1
friendly_name [Awesome custom component]:
```